### PR TITLE
Register ACF Select and Radio Fields as GraphQL Enum Types

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -602,21 +602,20 @@ class Config {
 				 *
 				 * @see: https://github.com/wp-graphql/wp-graphql-acf/issues/25
 				 */
-				$enum_type = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
-				$enum_type = ! empty( $enum_type ) ? $enum_type : 'String';
+				$field_type = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
 				if ( empty( $acf_field['multiple'] ) ) {
 					if('array' === $acf_field['return_format'] ){
-						$field_config['type'] = [ 'list_of' => $enum_type ];
+						$field_config['type'] = [ 'list_of' => $field_type ];
 						$field_config['resolve'] = function( $root ) use ( $acf_field) {
 							$value = $this->get_acf_field_value( $root, $acf_field, true);
 
 							return ! empty( $value ) && is_array( $value ) ? $value : [];
 						};
 					}else{
-						$field_config['type'] = $enum_type;
+						$field_config['type'] = $field_type;
 					}
 				} else {
-					$field_config['type']    = [ 'list_of' => $enum_type ];
+					$field_config['type']    = [ 'list_of' => $field_type ];
 					$field_config['resolve'] = function( $root ) use ( $acf_field ) {
 						$value = $this->get_acf_field_value( $root, $acf_field );
 
@@ -625,9 +624,8 @@ class Config {
 				}
 				break;
 			case 'radio':
-				$enum_type            = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
-				$enum_type            = ! empty( $enum_type ) ? $enum_type : 'String';
-				$field_config['type'] = $enum_type;
+				$field_type           = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$field_config['type'] = $field_type;
 				break;
 			case 'number':
 			case 'range':
@@ -990,79 +988,79 @@ class Config {
 				// ACF 5.8.6 added more data to Google Maps field value
 				// https://www.advancedcustomfields.com/changelog/
 				if ( \acf_version_compare(acf_get_db_version(), '>=', '5.8.6' ) ) {
-                    $fields += [
-                        'streetName' => [
+					$fields += [
+						'streetName' => [
 							'type'        => 'String',
 							'description' => __( 'The street name associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['street_name'] ) ? $root['street_name'] : null;
 							},
-                        ],
-                        'streetNumber' => [
+						],
+						'streetNumber' => [
 							'type'        => 'String',
 							'description' => __( 'The street number associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['street_number'] ) ? $root['street_number'] : null;
 							},
-                        ],
-                        'city' => [
+						],
+						'city' => [
 							'type'        => 'String',
 							'description' => __( 'The city associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['city'] ) ? $root['city'] : null;
 							},
-                        ],
-                        'state' => [
+						],
+						'state' => [
 							'type'        => 'String',
 							'description' => __( 'The state associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['state'] ) ? $root['state'] : null;
 							},
-                        ],
-                        'stateShort' => [
+						],
+						'stateShort' => [
 							'type'        => 'String',
 							'description' => __( 'The state abbreviation associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['state_short'] ) ? $root['state_short'] : null;
 							},
-                        ],
-                        'postCode' => [
+						],
+						'postCode' => [
 							'type'        => 'String',
 							'description' => __( 'The post code associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['post_code'] ) ? $root['post_code'] : null;
 							},
-                        ],
-                        'country' => [
+						],
+						'country' => [
 							'type'        => 'String',
 							'description' => __( 'The country associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['country'] ) ? $root['country'] : null;
 							},
-                        ],
-                        'countryShort' => [
+						],
+						'countryShort' => [
 							'type'        => 'String',
 							'description' => __( 'The country abbreviation associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['country_short'] ) ? $root['country_short'] : null;
 							},
-                        ],
-                        'placeId' => [
+						],
+						'placeId' => [
 							'type'        => 'String',
 							'description' => __( 'The country associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['place_id'] ) ? $root['place_id'] : null;
 							},
-                        ],
-                        'zoom' => [
+						],
+						'zoom' => [
 							'type'        => 'String',
 							'description' => __( 'The zoom defined with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['zoom'] ) ? $root['zoom'] : null;
 							},
-                        ],
-                    ];
-                }
+						],
+					];
+				}
 
 				$this->type_registry->register_object_type(
 					$field_type_name,
@@ -1506,12 +1504,12 @@ class Config {
 	}
 
 	public function register_choices_of_acf_fields_as_enum_type( array $acf_field ): string {
-		// If the field isn't a select or radio field, return an empty string.
-		if ( 'select' !== $acf_field['type'] && 'radio' !== $acf_field['type'] ) {
-			return '';
+		// If the field isn't a select or radio field or if there are no choices available, return 'String'.
+		if ( ( 'select' !== $acf_field['type'] && 'radio' !== $acf_field['type'] ) || empty( $acf_field['choices'] ) ) {
+			return 'String';
 		}
 
-		// Generate a unique name for the enum type using the field key.
+		// Generate a unique name for the enum type using the field name.
 		$enum_type_name = ucfirst( self::camel_case( $acf_field['name'] ) ) . 'Enum';
 		if ( ! $this->type_registry->has_type( $enum_type_name ) ) {
 			// Initialize an empty array to hold your enum values.

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -602,19 +602,21 @@ class Config {
 				 *
 				 * @see: https://github.com/wp-graphql/wp-graphql-acf/issues/25
 				 */
+				$enum_type = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$enum_type = ! empty( $enum_type ) ? $enum_type : 'String';
 				if ( empty( $acf_field['multiple'] ) ) {
 					if('array' === $acf_field['return_format'] ){
-						$field_config['type'] = [ 'list_of' => 'String' ];
+						$field_config['type'] = [ 'list_of' => $enum_type ];
 						$field_config['resolve'] = function( $root ) use ( $acf_field) {
 							$value = $this->get_acf_field_value( $root, $acf_field, true);
 
 							return ! empty( $value ) && is_array( $value ) ? $value : [];
 						};
 					}else{
-						$field_config['type'] = 'String';
+						$field_config['type'] = $enum_type;
 					}
 				} else {
-					$field_config['type']    = [ 'list_of' => 'String' ];
+					$field_config['type']    = [ 'list_of' => $enum_type ];
 					$field_config['resolve'] = function( $root ) use ( $acf_field ) {
 						$value = $this->get_acf_field_value( $root, $acf_field );
 
@@ -623,7 +625,9 @@ class Config {
 				}
 				break;
 			case 'radio':
-				$field_config['type'] = 'String';
+				$enum_type            = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$enum_type            = ! empty( $enum_type ) ? $enum_type : 'String';
+				$field_config['type'] = $enum_type;
 				break;
 			case 'number':
 			case 'range':
@@ -1499,6 +1503,44 @@ class Config {
 			}
 		}
 
+	}
+
+	public function register_choices_of_acf_fields_as_enum_type( array $acf_field ): string {
+		// If the field isn't a select or radio field, return an empty string.
+		if ( 'select' !== $acf_field['type'] && 'radio' !== $acf_field['type'] ) {
+			return '';
+		}
+
+		// Generate a unique name for the enum type using the field key.
+		$enum_type_name = ucfirst( self::camel_case( $acf_field['name'] ) ) . 'Enum';
+		if ( ! $this->type_registry->has_type( $enum_type_name ) ) {
+			// Initialize an empty array to hold your enum values.
+			$enum_values = [];
+
+			// Loop over the choices in the field and add them to the enum values array.
+			foreach ( $acf_field['choices'] as $key => $choice ) {
+				// Use the sanitize_key function to create a valid enum name from the choice key.
+				$enum_key = strtoupper( sanitize_key( $key ) );
+
+				// Add the choice to the enum values array.
+				$enum_values[ $enum_key ] = [
+					'value'       => $key,
+					'description' => $choice,
+				];
+			}
+
+			// Register enum type.
+			$this->type_registry->register_enum_type(
+				$enum_type_name,
+				[
+					'description' => $acf_field['label'],
+					'values'      => $enum_values,
+				]
+			);
+		}
+
+		// Return the enum type name.
+		return $enum_type_name;
 	}
 
 }

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -988,79 +988,79 @@ class Config {
 				// ACF 5.8.6 added more data to Google Maps field value
 				// https://www.advancedcustomfields.com/changelog/
 				if ( \acf_version_compare(acf_get_db_version(), '>=', '5.8.6' ) ) {
-					$fields += [
-						'streetName' => [
+                    $fields += [
+                        'streetName' => [
 							'type'        => 'String',
 							'description' => __( 'The street name associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['street_name'] ) ? $root['street_name'] : null;
 							},
-						],
-						'streetNumber' => [
+                        ],
+                        'streetNumber' => [
 							'type'        => 'String',
 							'description' => __( 'The street number associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['street_number'] ) ? $root['street_number'] : null;
 							},
-						],
-						'city' => [
+                        ],
+                        'city' => [
 							'type'        => 'String',
 							'description' => __( 'The city associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['city'] ) ? $root['city'] : null;
 							},
-						],
-						'state' => [
+                        ],
+                        'state' => [
 							'type'        => 'String',
 							'description' => __( 'The state associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['state'] ) ? $root['state'] : null;
 							},
-						],
-						'stateShort' => [
+                        ],
+                        'stateShort' => [
 							'type'        => 'String',
 							'description' => __( 'The state abbreviation associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['state_short'] ) ? $root['state_short'] : null;
 							},
-						],
-						'postCode' => [
+                        ],
+                        'postCode' => [
 							'type'        => 'String',
 							'description' => __( 'The post code associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['post_code'] ) ? $root['post_code'] : null;
 							},
-						],
-						'country' => [
+                        ],
+                        'country' => [
 							'type'        => 'String',
 							'description' => __( 'The country associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['country'] ) ? $root['country'] : null;
 							},
-						],
-						'countryShort' => [
+                        ],
+                        'countryShort' => [
 							'type'        => 'String',
 							'description' => __( 'The country abbreviation associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['country_short'] ) ? $root['country_short'] : null;
 							},
-						],
-						'placeId' => [
+                        ],
+                        'placeId' => [
 							'type'        => 'String',
 							'description' => __( 'The country associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['place_id'] ) ? $root['place_id'] : null;
 							},
-						],
-						'zoom' => [
+                        ],
+                        'zoom' => [
 							'type'        => 'String',
 							'description' => __( 'The zoom defined with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['zoom'] ) ? $root['zoom'] : null;
 							},
-						],
-					];
-				}
+                        ],
+                    ];
+                }
 
 				$this->type_registry->register_object_type(
 					$field_type_name,

--- a/src/class-mutations.php
+++ b/src/class-mutations.php
@@ -318,11 +318,9 @@ class Mutations
 			case 'textarea':
 				$field_config['type'] = 'String';
 				break;
-
 			case 'radio':
-				$enum_type            = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
-				$enum_type            = ! empty( $enum_type ) ? $enum_type : 'String';
-				$field_config['type'] = $enum_type;
+				$field_type           = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$field_config['type'] = $field_type;
 				break;
 			case 'select':
 
@@ -331,12 +329,11 @@ class Mutations
 				 * the field will accept a string, but if it is configured to allow
 				 * multiple values it will accept a list of strings
 				 */
-				$enum_type = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
-				$enum_type = ! empty( $enum_type ) ? $enum_type : 'String';
+				$field_type = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
 				if ( empty( $acf_field['multiple'] ) ) {
-					$field_config['type'] = $enum_type;
+					$field_config['type'] = $field_type;
 				} else {
-					$field_config['type'] = [ 'list_of' => $enum_type ];
+					$field_config['type'] = [ 'list_of' => $field_type ];
 				}
 				break;
 			case 'number':

--- a/src/class-mutations.php
+++ b/src/class-mutations.php
@@ -316,8 +316,13 @@ class Mutations
 			case 'wysiwyg':
 			case 'url':
 			case 'textarea':
-			case 'radio':
 				$field_config['type'] = 'String';
+				break;
+
+			case 'radio':
+				$enum_type            = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$enum_type            = ! empty( $enum_type ) ? $enum_type : 'String';
+				$field_config['type'] = $enum_type;
 				break;
 			case 'select':
 
@@ -326,10 +331,12 @@ class Mutations
 				 * the field will accept a string, but if it is configured to allow
 				 * multiple values it will accept a list of strings
 				 */
+				$enum_type = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$enum_type = ! empty( $enum_type ) ? $enum_type : 'String';
 				if ( empty( $acf_field['multiple'] ) ) {
-					$field_config['type'] = 'String';
+					$field_config['type'] = $enum_type;
 				} else {
-					$field_config['type'] = [ 'list_of' => 'String' ];
+					$field_config['type'] = [ 'list_of' => $enum_type ];
 				}
 				break;
 			case 'number':

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -7,7 +7,7 @@
  * Author URI:        https://www.wpgraphql.com
  * Text Domain:       wp-graphql-acf
  * Domain Path:       /languages
- * Version:           0.6.2
+ * Version:           0.6.1
  * Requires PHP:      7.0
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql-acf
  *
@@ -26,7 +26,7 @@ require_once( __DIR__ . '/vendor/autoload.php' );
  * Define constants
  */
 const WPGRAPHQL_REQUIRED_MIN_VERSION = '0.4.0';
-const WPGRAPHQL_ACF_VERSION = '0.6.2';
+const WPGRAPHQL_ACF_VERSION = '0.6.1';
 
 /**
  * Initialize the plugin

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -7,7 +7,7 @@
  * Author URI:        https://www.wpgraphql.com
  * Text Domain:       wp-graphql-acf
  * Domain Path:       /languages
- * Version:           0.6.1
+ * Version:           0.6.2
  * Requires PHP:      7.0
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql-acf
  *
@@ -26,7 +26,7 @@ require_once( __DIR__ . '/vendor/autoload.php' );
  * Define constants
  */
 const WPGRAPHQL_REQUIRED_MIN_VERSION = '0.4.0';
-const WPGRAPHQL_ACF_VERSION = '0.6.1';
+const WPGRAPHQL_ACF_VERSION = '0.6.2';
 
 /**
  * Initialize the plugin


### PR DESCRIPTION
This PR introduces a new feature to the `wp-graphql-acf` plugin that allows automatic registration of ACF select and radio fields as GraphQL Enum types. This feature enhances the plugin's type-safety.

The changes primarily consist of a new function `register_choices_of_acf_fields_as_enum_type` and modifications in the select and radio case block.

The `register_choices_of_acf_fields_as_enum_type` function takes an array representing an ACF field as input and checks if the field type is either 'select' or 'radio'. For such fields, the function generates a unique name and creates an array of Enum values using the provided choices in the field. If the enum type does not exist in the registry, it registers the enum type with its associated values and descriptions.

The modifications to the case block for the 'radio' type for example ensure that the newly registered enum type is used as the field's type.

```php
case 'radio':
	$enum_type            = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
	$enum_type            = ! empty( $enum_type ) ? $enum_type : 'String';
	$field_config['type'] = $enum_type;
	break;
```

This change not only enhances the functionality of the `wp-graphql-acf` plugin but also aligns it more closely with GraphQL's philosophy of strong typing. As such, it is expected to increase the robustness and reliability of interactions with ACF select and radio fields via the GraphQL API.

The new feature has been thoroughly tested to ensure its seamless operation with existing functionalities.

Please review the changes and provide any feedback or questions you might have.
